### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/_posts/2013-01-27-raven-js-1-0.md
+++ b/_posts/2013-01-27-raven-js-1-0.md
@@ -30,5 +30,5 @@ I hope you enjoy it!
 
 [1]: https://github.com/getsentry/raven-js
 [2]: https://github.com/getsentry/raven-js/issues
-[3]: https://raven-js.readthedocs.org
+[3]: https://raven-js.readthedocs.io
 [4]: https://getsentry.com


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
